### PR TITLE
Update TravisCI and Tox configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 sudo: false
+dist: bionic
 language: python
+python:
+- '3.6'
+- '3.7'
+- '3.8'
+- 'pypy3'
+matrix:
+  fast_finish: true
 install:
-  - travis_retry pip install tox
+  - travis_retry pip install tox-travis
 script: tox
 deploy:
   provider: pypi
@@ -11,4 +19,4 @@ deploy:
     secure: 0FrNZlMwzWptrCcIGpbm90+bvfz1FT+nFxJBzVj2C0l6CQDere/XZUWxYvsgivCKQC18pu2pWJaVjQgoxzdUVaKV93qcxJgns2puhXQCfBkFzF43RGofNQ32zLRmhArhygb2sgM6dlI9ZU5ccDFG13FWqJUNlFl5yasPUFVje17LcJOhX/aT/UHuLYP9wZHAoXVcrc2it2f8QmAkq5qJRzLgG/0F8PVAaDCOYTjYwXIY4efgttCSNN/koHBWxLHV83VRlr23ZsmNBy3xSx0qfvYoYZXoQL2xxzfadTqZv5zqjvF406HsHH9K1B3V5ztbTGctl9jr0igD4h11hVv1KHfFVLX9+9fVWSrBWt5aO1TIPQYYzhuVXye1MuIbaZLAk5MGN0Eo1QTFV/FuSma1dIldwf7Xai1XzqHFl6+y/CW60ghmFwo8atiuSAqqCWYrqg1n5oLfKXmfdYkihntVqwJrgGoPBHKK+IugzRy2AtiFoLEKtaQgKTwDJg8gzvPYnMqC0kBC7NOIO6VxBgjfJIaMd+w9WFakTcQn6yz08eQZXHd8CeZQMG7LxXbuiomwpgAv1aWQ9J0t27galJcU6f6F4c2FFk4mO6DndkuzUeTzGKQQLcdJa4Zdku0sK69iRmQ8pt8bt7zB2087vFG0tLbshEafQw/luQGyFT7EDeI=
   on:
     tags: true
-    repo: pmclanahan/urlwait
+    repo: pmac/urlwait

--- a/tests/test_urlwait.py
+++ b/tests/test_urlwait.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 import urlwait
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,15 @@
 [tox]
-envlist = py{27,33,34,35,36,py},flake8
+envlist = py{36,37,38,py3},flake8
 args_are_paths = false
 skip_missing_interpreters = true
 
 [testenv]
 commands = py.test
 deps =
-    pytest==2.8.7
-    mock==1.3.0
+    pytest==5.3.5
 
 [testenv:flake8]
-deps = flake8==2.5.2
+deps = flake8==3.7.9
 commands = flake8 urlwait.py tests
 
 [flake8]


### PR DESCRIPTION
Only test on Python 3.6 - 3.8 and use tox-travis.